### PR TITLE
changed target in webpack.config

### DIFF
--- a/app/templates/webpack.config.js
+++ b/app/templates/webpack.config.js
@@ -17,6 +17,6 @@ module.exports = {
     ]
   },
   <% if (electron) { %>
-  target: 'atom'
+  target: 'electron'
   <% } %>
 }


### PR DESCRIPTION
target `atom` is legacy fallback. Accroding to the doc we should use `electron` now